### PR TITLE
Created using Colaboratory,Fashion MNIST dataset

### DIFF
--- a/classification.ipynb
+++ b/classification.ipynb
@@ -1,0 +1,1019 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "classification.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyMm/qtC8UYTRXCyWOJz+PVG",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/Norah-Martin/Norah-Martin/blob/project/classification.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "CqlOzujoo7Pz"
+      },
+      "outputs": [],
+      "source": [
+        "#KERAS CHEAT SHEET TENSORFLOW\n",
+        "# 1.regression\n",
+        "# activation funtions   :HIDDEN LAYER - relu  OUTPUT LAYER = relu, linear\n",
+        "# loss fuctions         :mean_square_error,mean_absolute_error\n",
+        "\n",
+        "# 2.classification\n",
+        "# activation function    :#HIDDEN LAYER :relu OUTPUT LAYER: Binary(sigmoid),Multiclass(softmax)\n",
+        "# loss fuctions           :binary-binary_cross_entropy , multi-class(one-hot)cateogroical_cross_entropy,(multiclass,integers)sparse_categorical_cross_entropy\n",
+        "\n",
+        "# ANN -1 INPUT , 1 OR MORE THAN I HIDDEN LAYERS,1 OR MORE THAN 1 OUTPUT LAYER(flatten,dense,activation)\n",
+        "# CNN-CONV2D LAYER,MAXPOOL LAYER,ANN"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# ARTIFICAIL NEURAL NETWROK ANN"
+      ],
+      "metadata": {
+        "id": "opmOZxA9qQpi"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#steps to build ann model\n",
+        "# input layer       :if data in vector form,no need to flatten ,if not we need to flatten\n",
+        "# hidden layer      :activation function ,input_shape is mention\n",
+        "# output layer      :activation function\n",
+        "# compile           :loss function , optimzer :GD,SGD,Adam,Adagrad  ,metrics:Accuracy\n",
+        "# fit               :epochs,batch_size\n",
+        "# predict           :predict the new values and evaluate the model"
+      ],
+      "metadata": {
+        "id": "wFjefsM8rNxc"
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# first time the values may be wrong because trainable parameters(weights and bias),are randomly assigned\n",
+        "# we have to find the correct weights\n",
+        "# Intially error/loss will be more,accuracy will be more\n",
+        "# we do back propogation for increasing the accuracy and reducing the loss "
+      ],
+      "metadata": {
+        "id": "FMKV6jZWsUab"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import tensorflow as tf\n"
+      ],
+      "metadata": {
+        "id": "cpz20u_-NvoU"
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "(x_train,y_train),(x_test,y_test) = tf.keras.datasets.fashion_mnist.load_data()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "TM7ODLv-OI9T",
+        "outputId": "27777fbc-e5a8-4b0a-9673-18c9575ead0d"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-labels-idx1-ubyte.gz\n",
+            "32768/29515 [=================================] - 0s 0us/step\n",
+            "40960/29515 [=========================================] - 0s 0us/step\n",
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-images-idx3-ubyte.gz\n",
+            "26427392/26421880 [==============================] - 0s 0us/step\n",
+            "26435584/26421880 [==============================] - 0s 0us/step\n",
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-labels-idx1-ubyte.gz\n",
+            "16384/5148 [===============================================================================================] - 0s 0us/step\n",
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-images-idx3-ubyte.gz\n",
+            "4423680/4422102 [==============================] - 0s 0us/step\n",
+            "4431872/4422102 [==============================] - 0s 0us/step\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print (x_train.shape)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CbV5JrxSOAvL",
+        "outputId": "018ccc3d-cfed-4946-a27e-211d1d54c5eb"
+      },
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "(60000, 28, 28)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(x_test.shape)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "QRx90b8UOpLY",
+        "outputId": "8217c31d-61e2-493e-dcbe-045ba89bb007"
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "(10000, 28, 28)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        " label = 'T-shirt/top Trouser Pullover Dress Coat Sandal Shirt Sneaker Bag Ankle-boot'\n",
+        "label"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        },
+        "id": "1eCaMbFiOv2A",
+        "outputId": "32b432f0-3bb8-4cc4-bda1-7865159cbbe9"
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "'T-shirt/top Trouser Pullover Dress Coat Sandal Shirt Sneaker Bag Ankle-boot'"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "type(label)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "tIsDUMfEPgPf",
+        "outputId": "c0e6ed0b-e309-4028-ab0d-a16732c97336"
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "str"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 10
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "label =label.split()\n",
+        "label"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "MKKY6mw_PjmD",
+        "outputId": "3179ab67-5e96-4075-f83d-1cc2d6aa49a2"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['T-shirt/top',\n",
+              " 'Trouser',\n",
+              " 'Pullover',\n",
+              " 'Dress',\n",
+              " 'Coat',\n",
+              " 'Sandal',\n",
+              " 'Shirt',\n",
+              " 'Sneaker',\n",
+              " 'Bag',\n",
+              " 'Ankle-boot']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "type(label)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "C7TLD3rVPr1W",
+        "outputId": "90db76c8-6853-4360-e727-e60acdb32ae4"
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "list"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 12
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "len(label)"
+      ],
+      "metadata": {
+        "id": "JIgQG-UUs4-3",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "8f80e864-ed7e-4d1a-c48b-d116c7cc77bd"
+      },
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "10"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 13
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "i = 59999\n",
+        "plt.imshow(x_train[i],cmap = 'Blues')\n",
+        "plt.show()\n",
+        "print(f\"output : {label[y_train[i]]}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 282
+        },
+        "id": "fItAdi2qQADR",
+        "outputId": "6d66f29e-29e9-48ac-c946-dcfa34c7fc8e"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPe0lEQVR4nO3dfWxd9X3H8c83ziNxnlybJISQsDR9iBgE8MIqEAKhMYhUhU4tbf5o0ypS+AOmVkLTEJsG/zWa1lZt1SGlIyKbWiq0wsjWbGuWMSFom+KkgQQyIETObM+J7QTyQMiDne/+8Ellgs/vOPfcp/X7fkmWr8/3nnu+vrmf3OvzO+f8zN0F4HffpEY3AKA+CDsQBGEHgiDsQBCEHQhicj031t7e7kuWLK3nJoFQDh3q1tDQkI1XKxV2M7tH0ncltUj6O3ffmLr/kiVL9fLOrjKbBJBw6y2dubWKP8abWYukH0i6V9IKSWvNbEWljwegtsr8zb5K0gF3P+ju5yT9RNKa6rQFoNrKhH2RpJ4xP/dmyz7EzDaYWZeZdQ0ODZbYHIAyar433t03uXunu3d2tHfUenMAcpQJe5+kxWN+vjpbBqAJlQn7K5KWm9m1ZjZV0pckba1OWwCqreKhN3cfNrOHJP27RofeNrv761XrDEBVlRpnd/dtkrZVqRcANcThskAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IAjCDgRB2IEgSk3ZbGbdkk5KGpE07O6d1WgKQPWVCnvmTncfqsLjAKghPsYDQZQNu0v6uZntMrMN493BzDaYWZeZdQ0ODZbcHIBKlQ37be5+k6R7JT1oZrdfegd33+Tune7e2dHeUXJzACpVKuzu3pd9H5D0nKRV1WgKQPVVHHYzm2lmsy7elnS3pH3VagxAdZXZGz9f0nNmdvFxfuzu/1aVrgBUXcVhd/eDkm6oYi8AaoihNyAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgqjGBSfRxNw9Wc9OUa54/V+8czRZX7l4bm5t2uT0e83klnLvRanei37v30W8swNBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIyzI+nVQ8eT9dQ4uiTNnJb/Eus79kFy3UVtM5L1IrUcSx8euZCs9xxN/25trVNza3OumFJRT0V4ZweCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIBhnR9LO/neT9bMF4823LGvLrZ08M5xct+fo6WS96Hz4aVNacmsDJ84m1z1y8kyy3nMq3dvAqfPJ+p1L2nNr118zJ7lupQrf2c1ss5kNmNm+McvazGy7mb2dfZ9Xk+4AVM1EPsY/JemeS5Y9ImmHuy+XtCP7GUATKwy7u78o6dgli9dI2pLd3iLpvir3BaDKKt1BN9/d+7PbhyXNz7ujmW0wsy4z6xocGqxwcwDKKr033kev6pd7ZT933+Tune7e2dHeUXZzACpUadiPmNlCScq+D1SvJQC1UGnYt0pal91eJ+n56rQDoFYKx9nN7GlJd0hqN7NeSY9J2ijpGTNbL+mQpPtr2eRFtbwOeNH10VMaue2i7Zft7YHPXJusr32qK1n/2Kv/m1v7q7s+nlz3/bMjyXrLpILnbTj/GIDd/Zfuc/6wcyPpx755QXq0efeF9PEJk0r8s4xcyO8t1XVh2N19bU7prqJ1ATQPDpcFgiDsQBCEHQiCsANBEHYgiLqe4upq3DS6RZf+LTs9cBm1HLoreuzzieEpSZpScBrpd//k95P1J37VnVv7lzcPJ9f9ys3XJOsvHUhPF72sfWZu7c5luUd4S5J+05seOtvU1ZOsf2bJrGT9usWVn8Za6bAd7+xAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EETdLyWdODtPk5In6JUbjy47jv7Qs/tya/8zeCq57j+uX5Wsv382fUnluQVT+JZ5XorG0YtcOXtasv7Y3Z/Mrf3tyweT637tx3uS9ftvXJCsL5w7Pbf2n2+lr7fyX93vJet/WXB6bvus9PNSRvKU5sR6vLMDQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBB1HWc3SS1lrqFbwpnz6csSHzicHis/cfpcbu2ajtbkuo/87L+T9UMF4/TfKzhnfFHbjNxa6rLDE1H071X0+Kn1v3j9olLbHr6QPhf/yV8fyq2dKTiP/5urP5Wsl9WIS5fzzg4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQTTVdeOLpIZ0i8ZkT51JnzP+6Lb9yfqJk2dza7MLzl3etzd/2mJJulBwTftpX7whWU+p9XENZR5/8GT+sQuSdFXB83r6fPrftG1G/sv7CysXJ9ettVrOkZCn8J3dzDab2YCZ7Ruz7HEz6zOzPdnX6tq2CaCsiXyMf0rSPeMs/467r8y+tlW3LQDVVhh2d39R0rE69AKghsrsoHvIzF7LPubPy7uTmW0wsy4z6xoaGiyxOQBlVBr2JyQtk7RSUr+kb+Xd0d03uXunu3e2t3dUuDkAZVUUdnc/4u4j7n5B0g8lpS+fCqDhKgq7mS0c8+PnJOVfZxlAUygcZzezpyXdIandzHolPSbpDjNbqdGh825JD0xkY6Zy44stJYYmi67j/YPPX5+s7+zN30f5+Ruurqini/55X3ocvpbXIO85ejpZ/1VPeg70Xx46maz3v5v/+A/fviy57tEP0uPwn26bnay/9W5+b7dtfCG57spPpP/knJsYw5eko6fSvc+cnj8XwIJZ6XkC1v9B/rz1w4mDUQrD7u5rx1n8ZNF6AJoLh8sCQRB2IAjCDgRB2IEgCDsQRF1PcR2+4DqWGJJIDRtI0rTE9MInPjifXPdcwaWD3xxKDyF9Yt6s3Nq+nuPJdWdMbUnWl7flP7Yk/fH3X07Wjx8/k1ubXDAlc39femriKxfMSdaLTll+//3EEFTB0NuBofzfS5LmTEu/fKcnfvfTp9Ovl9+8mT60O/l7SZoyJf1v3lJiHHnNp/Knqh4eyf/34J0dCIKwA0EQdiAIwg4EQdiBIAg7EARhB4Ko6zj7ex+c1z+9kX8658OPPZNc/8oVn86tDfQMpDd++kS6fuSdZPl7T/xZbm3xrCuS615p6VNUv//L7mT9T++8Nln/2je359auWjo/uW7r7PzpniVpRsGpnH296WMM5rXlPzfz56Sfl6+sTE/pXHTq757e/GMIut/qTa674Jr8sWxJmj69XHTaEtNs9/WlX6tnE9OPp4574J0dCIKwA0EQdiAIwg4EQdiBIAg7EARhB4KwMlMoX66bbu70F3/x69z6v+4/nFx/cWv+mO3UgvO251yRvjzvlILzi3cczB/Hb52SHnOdOind28Dp/OmgJemq1unJuim/9zMj+WOyknTF5HTv751Ln7ddJPX6Wjq7Nbnu8bPpc87PFvxu5y7kX8NgpOB1f/XM9LETrQXj7KlrL0jS3Jn5r8dJBZdbT72Wb72lU7t2dY37ALyzA0EQdiAIwg4EQdiBIAg7EARhB4Ig7EAQdT2f3SRNbsn//+Wz111Vv2Yu09ob86fJBf4/KHxnN7PFZvaCmb1hZq+b2dez5W1mtt3M3s6+z6t9uwAqNZGP8cOSHnb3FZL+UNKDZrZC0iOSdrj7ckk7sp8BNKnCsLt7v7vvzm6flLRf0iJJayRtye62RdJ9tWoSQHmXtYPOzJZKulHSTknz3b0/Kx2WNO7Fzsxsg5l1mVnX4FB6/iwAtTPhsJtZq6SfSvqGu3/oing+erbDuGcWuPsmd+90986O9o5SzQKo3ITCbmZTNBr0H7n7s9niI2a2MKsvlFRweVcAjTSRvfEm6UlJ+93922NKWyWty26vk/R89dsDUC0TGWe/VdKXJe01sz3ZskclbZT0jJmtl3RI0v21aRFANRSG3d1fknKvjnBXddsBUCscLgsEQdiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EARhB4Ig7EAQE5mffbGZvWBmb5jZ62b29Wz542bWZ2Z7sq/VtW8XQKUmMj/7sKSH3X23mc2StMvMtme177j739SuPQDVMpH52fsl9We3T5rZfkmLat0YgOq6rL/ZzWyppBsl7cwWPWRmr5nZZjObl7POBjPrMrOuwaHBUs0CqNyEw25mrZJ+Kukb7n5C0hOSlklaqdF3/m+Nt567b3L3Tnfv7GjvqELLACoxobCb2RSNBv1H7v6sJLn7EXcfcfcLkn4oaVXt2gRQ1kT2xpukJyXtd/dvj1m+cMzdPidpX/XbA1AtE9kbf6ukL0vaa2Z7smWPSlprZisluaRuSQ/UpEMAVTGRvfEvSbJxStuq3w6AWuEIOiAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBDm7vXbmNmgpENjFrVLGqpbA5enWXtr1r4keqtUNXtb4u7jXv+trmH/yMbNuty9s2ENJDRrb83al0RvlapXb3yMB4Ig7EAQjQ77pgZvP6VZe2vWviR6q1Rdemvo3+wA6qfR7+wA6oSwA0E0JOxmdo+ZvWlmB8zskUb0kMfMus1sbzYNdVeDe9lsZgNmtm/MsjYz225mb2ffx51jr0G9NcU03olpxhv63DV6+vO6/81uZi2S3pL0R5J6Jb0iaa27v1HXRnKYWbekTndv+AEYZna7pFOS/t7dr8uW/bWkY+6+MfuPcp67/3mT9Pa4pFONnsY7m61o4dhpxiXdJ+mrauBzl+jrftXheWvEO/sqSQfc/aC7n5P0E0lrGtBH03P3FyUdu2TxGklbsttbNPpiqbuc3pqCu/e7++7s9klJF6cZb+hzl+irLhoR9kWSesb83Kvmmu/dJf3czHaZ2YZGNzOO+e7en90+LGl+I5sZR+E03vV0yTTjTfPcVTL9eVnsoPuo29z9Jkn3Snow+7jalHz0b7BmGjud0DTe9TLONOO/1cjnrtLpz8tqRNj7JC0e8/PV2bKm4O592fcBSc+p+aaiPnJxBt3s+0CD+/mtZprGe7xpxtUEz10jpz9vRNhfkbTczK41s6mSviRpawP6+Agzm5ntOJGZzZR0t5pvKuqtktZlt9dJer6BvXxIs0zjnTfNuBr83DV8+nN3r/uXpNUa3SP/jqS/aEQPOX39nqRXs6/XG92bpKc1+rHuvEb3bayX9DFJOyS9Lek/JLU1UW//IGmvpNc0GqyFDertNo1+RH9N0p7sa3Wjn7tEX3V53jhcFgiCHXRAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EMT/AWdPrjKg5tiNAAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "output : Sandal\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "  y_train"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Mq3iMTK6RsBl",
+        "outputId": "b8792a6b-b550-4d45-852b-0155660bbc8b"
+      },
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "array([9, 0, 0, ..., 3, 0, 5], dtype=uint8)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_train[0].max()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "AUqSkCPJSAO9",
+        "outputId": "76fc0392-bb29-4a2d-9d5b-a8b177e5f502"
+      },
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "255"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 16
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_train[0].min()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "vbZcwwp0SCZ1",
+        "outputId": "c9ac86c3-b186-41a7-c4bd-32a5d2f57e54"
+      },
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "0"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 17
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_train = x_train/255"
+      ],
+      "metadata": {
+        "id": "fpma_oSpSF3G"
+      },
+      "execution_count": 18,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_train[0].max()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "rCUkXqmASZLw",
+        "outputId": "0aac57ac-07ff-4670-db91-23a518c9f0d2"
+      },
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "1.0"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 19
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_test = x_test/255"
+      ],
+      "metadata": {
+        "id": "r3pPzS39SbB0"
+      },
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_test[0].max()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "R9kyDcWCTVtl",
+        "outputId": "a38d6a34-5b46-4f87-ea9b-36ba4f2a646b"
+      },
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "1.0"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 21
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_train[0].shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7wpcIMnnTuCw",
+        "outputId": "d058c632-744b-4946-b601-4fbc9dbf3bb9"
+      },
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(28, 28)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 22
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#flattening ths image\n",
+        "28*28"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "a5NJ3LS9UQiG",
+        "outputId": "104eb506-c654-45f9-b619-b32dece256e7"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "784"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 23
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#create a neural network input layer,hidden layer,output layer\n",
+        "#hidden layer = b/w inpout and outout,2/3rd of input+output\n",
+        "\n",
+        "# input = 784\n",
+        "# hidden = 532\n",
+        "# output = 10"
+      ],
+      "metadata": {
+        "id": "roLFZc8DTiGb"
+      },
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from tensorflow import keras\n",
+        "\n",
+        "model = keras.models.Sequential()\n",
+        "#model = tf.keras.Sequential()\n",
+        "model.add(tf.keras.layers.Flatten(input_shape=x_train[0].shape))\n",
+        "model.add(tf.keras.layers.Dense(532,activation='relu'))\n",
+        "model.add(tf.keras.layers.Dense(10,activation='softmax'))"
+      ],
+      "metadata": {
+        "id": "vfmaahq9Tryd"
+      },
+      "execution_count": 25,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model.compile(optimizer='adam',loss='sparse_categorical_crossentropy',metrics=['accuracy'])"
+      ],
+      "metadata": {
+        "id": "a0YgJCiSW0Al"
+      },
+      "execution_count": 26,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "history = model.fit(x_train,y_train,epochs=30)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "6wI3mW0AXp3s",
+        "outputId": "bc189cb2-f80b-49d8-8f2b-73454e37f743"
+      },
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/30\n",
+            "1875/1875 [==============================] - 7s 2ms/step - loss: 0.4725 - accuracy: 0.8319\n",
+            "Epoch 2/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.3582 - accuracy: 0.8685\n",
+            "Epoch 3/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.3208 - accuracy: 0.8813\n",
+            "Epoch 4/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2971 - accuracy: 0.8886\n",
+            "Epoch 5/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2796 - accuracy: 0.8954\n",
+            "Epoch 6/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2652 - accuracy: 0.9003\n",
+            "Epoch 7/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2521 - accuracy: 0.9039\n",
+            "Epoch 8/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2407 - accuracy: 0.9103\n",
+            "Epoch 9/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2313 - accuracy: 0.9130\n",
+            "Epoch 10/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2209 - accuracy: 0.9165\n",
+            "Epoch 11/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2129 - accuracy: 0.9206\n",
+            "Epoch 12/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.2027 - accuracy: 0.9238\n",
+            "Epoch 13/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1977 - accuracy: 0.9251\n",
+            "Epoch 14/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1915 - accuracy: 0.9282\n",
+            "Epoch 15/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1828 - accuracy: 0.9306\n",
+            "Epoch 16/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1804 - accuracy: 0.9312\n",
+            "Epoch 17/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1727 - accuracy: 0.9343\n",
+            "Epoch 18/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1669 - accuracy: 0.9365\n",
+            "Epoch 19/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1615 - accuracy: 0.9386\n",
+            "Epoch 20/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1574 - accuracy: 0.9405\n",
+            "Epoch 21/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1533 - accuracy: 0.9420\n",
+            "Epoch 22/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1479 - accuracy: 0.9444\n",
+            "Epoch 23/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1441 - accuracy: 0.9462\n",
+            "Epoch 24/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1407 - accuracy: 0.9470\n",
+            "Epoch 25/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1348 - accuracy: 0.9492\n",
+            "Epoch 26/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1352 - accuracy: 0.9486\n",
+            "Epoch 27/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1296 - accuracy: 0.9519\n",
+            "Epoch 28/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1263 - accuracy: 0.9519\n",
+            "Epoch 29/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1247 - accuracy: 0.9536\n",
+            "Epoch 30/30\n",
+            "1875/1875 [==============================] - 4s 2ms/step - loss: 0.1205 - accuracy: 0.9550\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model.get_weights() #optimized weights after training"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "fBsrwWwBYHkk",
+        "outputId": "638523d2-18e2-4706-ca06-c9ebad788b31"
+      },
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[array([[-0.07348466,  0.00194002, -0.14124414, ..., -0.08763411,\n",
+              "         -0.0755991 , -0.02597615],\n",
+              "        [-0.05274192,  0.5301053 , -0.12281501, ..., -0.03741921,\n",
+              "         -0.00525263,  0.06908023],\n",
+              "        [ 0.37222615,  0.1821872 ,  0.02485261, ..., -0.17685743,\n",
+              "          0.01545325,  0.02694104],\n",
+              "        ...,\n",
+              "        [ 0.03065552,  0.373297  ,  0.12375727, ..., -0.07779531,\n",
+              "         -0.5227426 ,  0.2678847 ],\n",
+              "        [ 0.7184549 ,  0.256457  ,  0.18616594, ..., -0.13179375,\n",
+              "         -0.47222656,  0.14371894],\n",
+              "        [-0.16635501,  0.8433843 , -0.07954372, ..., -0.27915388,\n",
+              "         -0.49803486,  0.09901921]], dtype=float32),\n",
+              " array([-2.52766341e-01,  1.12060606e+00,  2.71348894e-01, -7.53033254e-03,\n",
+              "         3.69028360e-01,  3.56216848e-01,  2.57926375e-01,  4.01279598e-01,\n",
+              "        -2.38179222e-01,  1.40152991e-01,  4.37058717e-01,  4.07655537e-01,\n",
+              "         2.11756587e-01,  1.61549971e-01,  9.22361985e-02,  3.86664093e-01,\n",
+              "         2.70025551e-01,  3.33937168e-01,  2.53881276e-01,  9.76698101e-02,\n",
+              "         3.15877408e-01,  5.83263636e-01, -1.77384503e-02,  2.44822130e-01,\n",
+              "         1.09856665e-01,  2.92226136e-01, -1.31934494e-01,  3.54683727e-01,\n",
+              "         2.62649864e-01, -6.02954291e-02, -9.89207998e-03,  7.03266338e-02,\n",
+              "         4.53407049e-01,  6.87125623e-01, -3.05307776e-01,  1.29803941e-01,\n",
+              "         3.65304559e-01,  1.48803040e-01,  1.64280787e-01,  5.03546655e-01,\n",
+              "         2.72809297e-01,  6.02590203e-01,  1.97056085e-01,  1.92002684e-01,\n",
+              "         1.44891903e-01,  1.43383414e-01,  2.23997980e-01,  4.88250345e-01,\n",
+              "         4.59939241e-01,  2.45087504e-01,  2.30700761e-01, -3.80385280e-01,\n",
+              "         3.95036153e-02,  3.74452382e-01,  1.61462590e-01,  6.98604435e-02,\n",
+              "        -3.00004095e-01,  2.43043944e-01,  4.79021609e-01,  7.77696073e-02,\n",
+              "         9.55793262e-02, -3.94921243e-01,  7.12275982e-01, -8.27106312e-02,\n",
+              "         1.48822278e-01,  5.54141641e-01,  1.68561101e-01,  4.83602583e-02,\n",
+              "         3.24876577e-01,  5.49832046e-01,  3.51744980e-01,  2.50725150e-01,\n",
+              "         2.18801886e-01,  4.04402316e-01,  4.17104736e-02,  4.69771594e-01,\n",
+              "        -2.65726503e-02,  9.77803022e-02,  7.19852149e-01, -1.21147847e-02,\n",
+              "        -2.24121474e-02, -1.88881010e-01, -1.94310769e-01, -1.79675043e-01,\n",
+              "         3.43566060e-01,  1.56762958e-01,  2.29411617e-01, -7.98714831e-02,\n",
+              "         2.20830739e-01,  1.04513876e-02,  1.82018206e-01,  3.13746512e-01,\n",
+              "         8.16527009e-01,  6.50778413e-01, -1.91902760e-02,  7.66120493e-01,\n",
+              "        -1.59329716e-02,  4.77737278e-01,  1.47738392e-02,  7.11646229e-02,\n",
+              "        -7.56012127e-02,  4.66006875e-01,  2.86119819e-01,  2.33393803e-01,\n",
+              "         2.70963222e-01,  4.67780352e-01, -4.04612534e-03,  8.47467422e-01,\n",
+              "         1.15486652e-01,  1.87296718e-01,  3.49372029e-01,  1.84127778e-01,\n",
+              "         3.83041292e-01,  3.36022794e-01, -1.16883125e-02, -1.33278724e-02,\n",
+              "        -1.06620668e-02, -2.09379196e-02,  7.60240257e-01,  5.93063951e-01,\n",
+              "         8.03821146e-01,  3.21336091e-01, -2.26368755e-01,  1.44118471e-02,\n",
+              "         3.66217941e-01, -4.85553741e-02, -5.09747446e-01,  4.72868651e-01,\n",
+              "         2.21857265e-01,  3.61660182e-01, -8.62111822e-02,  5.95082223e-01,\n",
+              "         3.79624844e-01,  3.79905373e-01,  9.80903395e-03,  4.25470233e-01,\n",
+              "         6.19830370e-01,  4.37699497e-01, -1.65727809e-02,  2.64356673e-01,\n",
+              "         2.88807660e-01, -1.25201587e-02,  3.39739472e-01,  2.16515064e-01,\n",
+              "        -4.74147409e-01, -2.25512944e-02,  2.83963174e-01, -2.16962094e-03,\n",
+              "         6.88122630e-01,  7.18079865e-01,  3.18854898e-01, -2.73845792e-02,\n",
+              "         5.38136005e-01, -8.67359042e-01,  1.14662409e-01,  3.43228906e-01,\n",
+              "         4.75982606e-01, -6.94834366e-02,  2.28544712e-01,  4.61664706e-01,\n",
+              "         2.17269361e-01,  3.73669952e-01,  5.13594627e-01,  1.36455566e-01,\n",
+              "         2.66921341e-01, -8.40115827e-03,  4.44600806e-02,  1.95702568e-01,\n",
+              "        -7.69942701e-01, -2.33825799e-02, -8.10767114e-02,  9.90997404e-02,\n",
+              "        -2.54029259e-02,  4.04873371e-01, -2.61912793e-02,  2.45126605e-01,\n",
+              "         2.02952158e-02,  2.60702401e-01,  9.09702294e-03,  5.16447544e-01,\n",
+              "         2.95953453e-01,  1.61626220e-01,  3.57955039e-01,  6.85655624e-02,\n",
+              "        -4.70591374e-02,  6.10988401e-02, -9.28173307e-03,  5.63190043e-01,\n",
+              "         6.26425073e-02,  1.18031122e-01,  2.32187629e-01,  3.28010559e-01,\n",
+              "         5.28357685e-01,  5.69631040e-01, -1.12221643e-01, -1.19730592e-01,\n",
+              "         3.21772426e-01,  2.84632772e-01,  1.14856184e+00,  6.38002098e-01,\n",
+              "         5.69431931e-02, -1.02586420e-02,  6.35086954e-01, -1.13078288e-03,\n",
+              "        -1.11714480e-02, -1.14215044e-02,  2.79378533e-01,  5.64627588e-01,\n",
+              "         3.07488710e-01, -4.17500287e-01, -3.24472710e-02,  2.54672676e-01,\n",
+              "         6.96970940e-01,  6.41378999e-01, -8.77270196e-03, -1.59497540e-02,\n",
+              "         5.70840418e-01, -1.90298427e-02,  3.64722192e-01,  1.58562645e-01,\n",
+              "         4.46107358e-01, -9.56677832e-03,  1.03637345e-01,  7.13316858e-01,\n",
+              "        -2.08165482e-01,  1.07801378e-01,  1.81589007e-01,  3.01923454e-01,\n",
+              "        -2.61989176e-01,  1.59217671e-01,  9.71830368e-01,  4.51362520e-01,\n",
+              "         4.67545927e-01, -4.54685315e-02,  6.61990568e-02,  1.81887850e-01,\n",
+              "         1.57321855e-01,  1.20261776e+00,  4.34455544e-01,  6.55178905e-01,\n",
+              "        -5.00285849e-02,  2.44461596e-01,  3.44770581e-01,  4.23476174e-02,\n",
+              "        -3.77237797e-02,  7.21457526e-02,  1.16077036e-01,  2.77350664e-01,\n",
+              "         4.86864269e-01,  3.63808423e-01,  2.60357976e-01,  1.94792986e-01,\n",
+              "        -3.16631943e-01,  7.30912983e-02, -1.98553413e-01, -1.19419461e-02,\n",
+              "         3.11766297e-01, -3.69984388e-01, -1.99114960e-02, -1.52036920e-01,\n",
+              "         3.17153662e-01,  3.08286786e-01,  8.92619967e-01,  1.07750022e+00,\n",
+              "         1.78625464e-01,  4.84288990e-01, -1.80866957e-01, -2.75481828e-02,\n",
+              "         2.05898032e-01,  2.35755205e-01,  1.51226312e-01, -8.08563363e-03,\n",
+              "         2.14101732e-01, -3.73088103e-03,  3.42836380e-01,  1.24821454e-01,\n",
+              "         1.53210074e-01, -1.05320094e-02, -1.52793396e-02,  2.51008034e-01,\n",
+              "         2.84812301e-01,  6.46394908e-01,  1.00454405e-01,  9.84142348e-02,\n",
+              "        -1.09835997e-01,  5.30656755e-01,  8.21275175e-01,  2.28864133e-01,\n",
+              "        -8.09859764e-03,  6.45892143e-01,  2.44663656e-01, -9.27339401e-03,\n",
+              "        -1.59774154e-01,  5.61135933e-02,  2.10071146e-01, -3.43920738e-02,\n",
+              "         5.78654528e-01, -9.70868841e-02,  3.28447104e-01, -5.88497929e-02,\n",
+              "         5.10499179e-01,  2.63882875e-01,  4.38904256e-01,  1.46555305e-01,\n",
+              "         1.63422480e-01,  6.09794259e-01, -3.02752517e-02,  1.80860654e-01,\n",
+              "        -2.21999474e-02, -3.72565840e-03,  6.99783504e-01,  2.43036881e-01,\n",
+              "        -1.34390267e-02, -1.31940499e-01,  1.20709062e-01, -3.06630582e-02,\n",
+              "         1.02791265e-01,  1.53997123e-01,  7.65848458e-02,  2.06503466e-01,\n",
+              "         2.24177688e-01,  1.65077686e-01, -1.94482237e-01,  4.83188897e-01,\n",
+              "         4.39448833e-01, -3.35068665e-02, -2.93634161e-02,  4.44882326e-02,\n",
+              "         2.35785052e-01,  3.81207645e-01,  3.06033731e-01,  7.13386714e-01,\n",
+              "         7.40540087e-01,  2.60166317e-01,  4.52837437e-01, -2.28075311e-01,\n",
+              "         2.17706591e-01,  7.95110047e-01,  5.60883820e-01, -1.02560125e-01,\n",
+              "         4.76726592e-02, -1.60816312e-01,  3.77295554e-01, -8.80714692e-03,\n",
+              "        -5.52545786e-02,  4.27596897e-01,  3.07861358e-01, -6.46400973e-02,\n",
+              "         2.21791953e-01,  5.60038865e-01,  5.17755002e-02,  3.16747606e-01,\n",
+              "        -7.12972088e-03,  1.47534192e-01,  3.54167819e-01, -2.63897348e-02,\n",
+              "        -1.19389258e-02,  7.77517185e-02, -1.02123367e-02,  1.06458530e-01,\n",
+              "        -6.96337670e-02,  5.26259422e-01, -3.83776695e-01,  2.15937778e-01,\n",
+              "         5.20745337e-01, -2.35771954e-01,  3.77959728e-01,  4.38561708e-01,\n",
+              "        -1.81265160e-01, -2.43971974e-01,  7.49647260e-01,  7.19072640e-01,\n",
+              "         5.93855739e-01,  1.05939537e-01, -3.26454222e-01, -1.58947539e-02,\n",
+              "         6.10287525e-02, -1.71342157e-02,  5.64393342e-01,  3.09731215e-01,\n",
+              "         3.63737136e-01,  2.63314843e-01,  3.62887263e-01,  1.66749045e-01,\n",
+              "         1.30593970e-01, -8.81528631e-02,  2.50403911e-01,  2.79303730e-01,\n",
+              "         1.56678349e-01, -2.68761273e-02,  4.61802095e-01,  1.33006766e-01,\n",
+              "         8.24400425e-01,  3.15009266e-01, -9.92957596e-03,  1.02659613e-01,\n",
+              "        -1.23009928e-01,  5.65160096e-01,  5.09530842e-01, -2.54129916e-01,\n",
+              "         2.01805055e-01,  6.45017505e-01,  3.42189491e-01,  5.85858047e-01,\n",
+              "         2.20503658e-03, -1.47449076e-02,  2.04701573e-01,  5.74508429e-01,\n",
+              "         1.55596375e-01,  2.53791004e-01,  2.90394217e-01,  3.11883062e-01,\n",
+              "         6.23039782e-01, -1.62303690e-02,  1.50119513e-01,  4.33083922e-01,\n",
+              "        -7.92893171e-02,  4.50810552e-01, -1.54589415e-02,  4.99053985e-01,\n",
+              "         4.20560129e-02,  1.30413007e-02, -1.15934536e-02,  4.00028735e-01,\n",
+              "        -6.44823583e-03,  5.17606214e-02,  1.40960127e-01,  1.42551130e-02,\n",
+              "         6.77309096e-01,  3.74029696e-01, -1.34842061e-02, -1.00574950e-02,\n",
+              "         1.19196214e-01, -8.91799778e-02,  1.13725170e-01,  3.86053056e-01,\n",
+              "        -1.70151610e-02, -1.36342151e-02,  5.80967963e-01, -1.32251494e-02,\n",
+              "         2.98726976e-01, -2.05073059e-02, -2.14015350e-01,  4.53233421e-01,\n",
+              "         8.98997247e-01,  6.05319142e-01,  1.70600370e-01,  2.04746649e-01,\n",
+              "        -1.53942451e-01,  1.14431709e-01,  5.85301161e-01,  9.17039096e-01,\n",
+              "        -9.46118534e-02,  2.37723544e-01,  8.01821172e-01,  5.02351701e-01,\n",
+              "        -2.15876758e-01, -7.58851739e-03,  1.82211354e-01,  3.94013226e-01,\n",
+              "         2.15976741e-02, -7.96791673e-01,  1.00088298e-01, -6.21147573e-01,\n",
+              "         2.84124672e-01,  2.15751633e-01,  2.31609732e-01,  2.18909055e-01,\n",
+              "         3.79353650e-02, -1.58336274e-02, -1.39077650e-02, -2.49837354e-01,\n",
+              "        -1.21027287e-02, -1.02541456e-02,  2.86248684e-01, -1.49966888e-02,\n",
+              "         3.44332963e-01,  4.96010363e-01,  4.16158229e-01,  3.66599768e-01,\n",
+              "         1.24525046e-03,  2.08027616e-01,  1.00901380e-01,  8.34016025e-01,\n",
+              "        -1.56294312e-02,  1.67463645e-02,  2.60627717e-01,  1.67510398e-02,\n",
+              "         1.18936434e-01,  3.20001364e-01,  1.79659024e-01,  2.48228788e-01,\n",
+              "         3.94131467e-02,  2.00293168e-01, -1.60650201e-02,  2.32597902e-01,\n",
+              "         2.94714749e-01,  5.93302786e-01, -1.45791080e-02, -3.05233151e-02,\n",
+              "         3.22296977e-01, -1.33549394e-02,  6.89648569e-01,  4.16349381e-01,\n",
+              "         5.59562445e-01,  6.49845779e-01, -1.58750322e-02,  2.72942007e-01,\n",
+              "         7.18746006e-01, -4.90700677e-02, -1.33672744e-01, -1.12200305e-02,\n",
+              "         2.10356206e-01, -2.01416537e-02, -2.13207658e-02,  8.85482803e-02,\n",
+              "         3.89947414e-01, -6.99200034e-02,  7.01266825e-01,  2.98968732e-01,\n",
+              "        -2.42941931e-01,  1.95525363e-01,  5.92540026e-01,  1.50394931e-01,\n",
+              "        -1.91941895e-02, -7.83106089e-02,  3.75121087e-02,  2.29142293e-01,\n",
+              "        -4.70500052e-01, -1.01597700e-02,  1.90678954e-01,  6.07734136e-02],\n",
+              "       dtype=float32),\n",
+              " array([[-0.08404822,  0.20631431,  0.08243199, ...,  0.00557827,\n",
+              "         -0.08035113, -0.51539713],\n",
+              "        [-0.14970995, -0.40588558,  0.30442128, ...,  0.13505244,\n",
+              "         -0.10827195, -0.97489953],\n",
+              "        [-0.03614644,  0.21256247,  0.18016921, ..., -0.22464629,\n",
+              "         -0.51454276, -0.09607916],\n",
+              "        ...,\n",
+              "        [-0.10928112, -0.18467009, -0.11564273, ..., -0.00239286,\n",
+              "          0.47840235, -0.02505674],\n",
+              "        [-0.82836103,  0.05229995,  0.24453934, ...,  0.26806214,\n",
+              "          0.5082394 , -0.1713125 ],\n",
+              "        [ 0.02788212, -0.04796163, -0.17344384, ..., -0.20947696,\n",
+              "          0.00691035, -0.13675213]], dtype=float32),\n",
+              " array([-0.13473538, -0.7059771 ,  0.16183366,  0.5269999 , -0.44323492,\n",
+              "        -0.31411308,  0.23197508,  0.17683716,  0.31334293, -0.35377502],\n",
+              "       dtype=float32)]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 28
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import numpy as np\n",
+        "y_pred=np.argmax(model.predict(x_test),axis=1)\n",
+        "y_pred"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ri5yjV6AaYKB",
+        "outputId": "f7fcae8e-2e12-4d4f-b1e6-2e85d330e972"
+      },
+      "execution_count": 32,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "array([9, 2, 1, ..., 8, 1, 5])"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 32
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "y_test"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "QM3dYJhda2nd",
+        "outputId": "e586dfcf-6819-4ead-94b9-7c943009152e"
+      },
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "array([9, 2, 1, ..., 8, 1, 5], dtype=uint8)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 30
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from sklearn.metrics import accuracy_score\n",
+        "accuracy_score(y_test,y_pred)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gtpDf_Ioa4Nj",
+        "outputId": "cf005d19-1197-4588-ca92-1d956c7fc384"
+      },
+      "execution_count": 34,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "0.8968"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 34
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#saving the neurak networks model in a hdf5 file \n",
+        "model.save('fashionmnsit.hd5f')\n",
+        "#hierachial data format version 5"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_NTh2fL-aocT",
+        "outputId": "2d54fd1c-a207-4720-a2bf-becdee88a34f"
+      },
+      "execution_count": 35,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "INFO:tensorflow:Assets written to: fashionmnsit.hd5f/assets\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#to load the model and use it\n",
+        "#keras.models.load_model('fashionmnist.hdf5')\n"
+      ],
+      "metadata": {
+        "id": "vTy6mNT1bucQ"
+      },
+      "execution_count": 37,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#end of ann "
+      ],
+      "metadata": {
+        "id": "FcFgCZcEdN-N"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
This is a dataset of 60,000 28x28 grayscale images of 10 fashion categories, along with a test set of 10,000 images. This dataset can be used as a drop-in replacement for MNIST